### PR TITLE
Add AdminInterface::setContractTranslator method

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2466,11 +2466,9 @@ EOT;
      *
      * NEXT_MAJOR: remove this method
      *
-     * @param LegacyTranslatorInterface|TranslatorInterface $translator
-     *
      * @deprecated since sonata-project/admin-bundle 3.9, to be removed with 4.0
      */
-    public function setTranslator(object $translator)
+    public function setTranslator(LegacyTranslatorInterface $translator)
     {
         $args = \func_get_args();
         if (isset($args[1]) && $args[1]) {
@@ -2480,16 +2478,11 @@ EOT;
             ), E_USER_DEPRECATED);
         }
 
-        if (!$translator instanceof LegacyTranslatorInterface && !$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf(
-                'Argument 1 passed to "%s()" must be an instance of "%s" or "%s", instance of "%s" given.',
-                __METHOD__,
-                LegacyTranslatorInterface::class,
-                TranslatorInterface::class,
-                \get_class($translator)
-            ));
-        }
+        $this->translator = $translator;
+    }
 
+    public function setContractTranslator(TranslatorInterface $translator): void
+    {
         $this->translator = $translator;
     }
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -65,7 +65,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * @method void                            reorderFormGroup(string $group, array $keys)
  * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
  * @method string                          getPagerType()
- * @method void                            setTranslator(object $translator);
+ * @method void                            setContractTranslator(TranslatorInterface $translator);
  */
 interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
@@ -91,6 +91,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return DatagridBuilderInterface
      */
     public function getDatagridBuilder();
+
+    public function setTranslator(LegacyTranslatorInterface $translator);
 
     /**
      * @return TranslatorInterface|LegacyTranslatorInterface

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 
 /**
  * Add all dependencies to the Admin class, this avoid to write too many lines
@@ -276,7 +277,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'show_builder' => sprintf('sonata.admin.builder.%s_show', $managerType),
             'list_builder' => sprintf('sonata.admin.builder.%s_list', $managerType),
             'datagrid_builder' => sprintf('sonata.admin.builder.%s_datagrid', $managerType),
-            'translator' => 'translator',
+            'contract_translator' => 'translator',
             'configuration_pool' => 'sonata.admin.pool',
             'route_generator' => 'sonata.admin.route.default_generator',
             'validator' => 'validator',
@@ -286,6 +287,9 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 (('doctrine_phpcr' === $managerType) ? '_slashes' : ''),
             'label_translator_strategy' => 'sonata.admin.label.strategy.native',
         ];
+        if ($container->hasDefinition('translator') && in_array(LegacyTranslatorInterface::class, class_implements($container->getDefinition('translator')->getClass()), true)) {
+            $defaultAddServices['translator'] = 'translator';
+        }
 
         $definition->addMethodCall('setManagerType', [$managerType]);
 


### PR DESCRIPTION
Hi @dmaicher, haven't fully tried, but what about adding another method (I called it `setContractTranslator` for instance) and call this method from the compiler pass? I haven't change the `AdminTest` class, this is just to see if this would work. 